### PR TITLE
feat(blog): tornar menu responsivo 

### DIFF
--- a/blog/assets/styles/style.css
+++ b/blog/assets/styles/style.css
@@ -15,7 +15,7 @@ body {
 }
 
 main {
-    padding: 132px 0 32px 200px;
+    padding: 132px 0 32px;
 }
 
 h1 {
@@ -117,7 +117,6 @@ header#header>p {
 }
 
 @keyframes gradientBlue {
-
     0% {
         background-position: 10% 0%;
     }
@@ -137,28 +136,51 @@ aside {
     color: #fff;
     padding: 16px 16px 8px;
 
-    width: 200px;
+    width: 100%;
     position: fixed;
     top: 100px;
     bottom: 0;
+    left: 0;
+    z-index: 999;
 }
 
 aside a {
     color: #fff;
 }
 
+nav {
+    height: 100%;
+    display: flex;
+}
+
 nav ul {
     list-style: none;
     padding: 0;
+    width: 80%;
+    height: 80%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-around;
+    margin: auto;
+}
+
+nav ul li {
+    flex: 1;
+    display: flex;
 }
 
 nav ul a {
-    display: block;
+    flex: 1;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     opacity: 0.7;
     transition: opacity 300ms;
     position: relative;
     width: 100%;
     overflow: hidden;
+    text-align: center;
+    font-size: 32px;
 }
 
 nav ul a::before {
@@ -185,6 +207,7 @@ nav ul a:hover::before {
 .menu-button {
     width: 40px;
     height: 40px;
+    display: block;
     position: absolute;
     top: 50%;
     right: 32px;
@@ -240,4 +263,36 @@ nav ul a:hover::before {
     left: 0;
     bottom: 0;
     transform: rotate(-90deg);
+}
+
+@media (min-width: 600px) {
+    main {
+        padding-left: 200px;
+    }
+
+    aside {
+        width: 200px;
+    }
+
+    nav,
+    nav ul,
+    nav ul li,
+    nav ul a {
+        display: block;
+    }
+
+    nav ul {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+    }
+
+    nav ul a {
+        text-align: start;
+        font-size: 16px;
+    }
+
+    .menu-button {
+        display: none;
+    }
 }


### PR DESCRIPTION
### Descrição

Quando a página tiver menos que 600px (tamanho mobile), o botão do menu será exibido ao usuário, e o menu será transformado para ocupar toda a tela do dispositivo.

Quando a página tiver mais que 600px (tamanho desktop), o botão do menu será ocultado, e o menu ocupará somente uma parte pequena da tela.